### PR TITLE
feat: simplify container naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,10 @@ You can now access with your browser to:
 - [your Symfony web application](http://localhost:8741).
 - [phpmyadmin](http://localhost:8080).
 - [mail](http://localhost:8081).
+
+## Stop the system
+
+```bash
+docker stop {phpmyadmin_symfony,www_symfony,maildev_symfony,db_symfony}
+```
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   
   db:
     image: mysql
-    container_name: db_docker_symfony
+    container_name: db_symfony
     restart: always
     volumes:
       - db-data:/var/lib/mysql
@@ -15,7 +15,7 @@ services:
   
   phpmyadmin:
     image: phpmyadmin
-    container_name: phpmyadmin_docker_symfony
+    container_name: phpmyadmin_symfony
     restart: always
     depends_on:
       - db
@@ -28,7 +28,7 @@ services:
   
   maildev:
     image: maildev/maildev
-    container_name: maildev_docker_symfony
+    container_name: maildev_symfony
     command: bin/maildev --web 80 --smtp 25 --hide-extensions STARTTLS
     ports:
       - 8081:80
@@ -38,7 +38,7 @@ services:
   
   www:
     build: php
-    container_name: www_docker_symfony
+    container_name: www_symfony
     ports:
       - "8741:80"
     volumes:


### PR DESCRIPTION
As it is already a docker image I suggest not to put docker in the name. -symfony suffix is a good idea

Linux Stop command example added to show how to restart the containers.